### PR TITLE
Krah/dataset unbroken

### DIFF
--- a/spandex-common/src/main/scala/com/socrata/spandex/common/client/ResponseExtensions.scala
+++ b/spandex-common/src/main/scala/com/socrata/spandex/common/client/ResponseExtensions.scala
@@ -89,8 +89,7 @@ case class FieldValue(datasetId: String,
                       value: String) {
   lazy val docId = FieldValue.makeDocId(datasetId, copyNumber, columnId, rowId)
   lazy val compositeId = FieldValue.makeCompositeId(datasetId, copyNumber, columnId)
-  // *sigh* a cluster side analysis char_filter doesn't catch this one character in time.
-  lazy val completionValue = CompletionValue(value.replaceAll("\u001f", ""))
+  lazy val completionValue = CompletionValue(value)
 
   // Needed for codec builder
   def this(datasetId: String,

--- a/spandex-common/src/main/scala/com/socrata/spandex/common/client/ResponseExtensions.scala
+++ b/spandex-common/src/main/scala/com/socrata/spandex/common/client/ResponseExtensions.scala
@@ -89,7 +89,8 @@ case class FieldValue(datasetId: String,
                       value: String) {
   lazy val docId = FieldValue.makeDocId(datasetId, copyNumber, columnId, rowId)
   lazy val compositeId = FieldValue.makeCompositeId(datasetId, copyNumber, columnId)
-  lazy val completionValue = CompletionValue(value)
+  // *sigh* a cluster side analysis char_filter doesn't catch this one character in time.
+  lazy val completionValue = CompletionValue(value.replaceAll("\u001f", ""))
 
   // Needed for codec builder
   def this(datasetId: String,

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/client/SpandexElasticSearchClientSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/client/SpandexElasticSearchClientSpec.scala
@@ -333,21 +333,4 @@ class SpandexElasticSearchClientSpec extends FunSuiteLike with Matchers with Bef
 
     client.indexFieldValue(FieldValue(datasets(0), 1L, 2L, 61L, ""), refresh = true)
   }
-
-  // once upon a time we got this exception:
-  // org.elasticsearch.index.mapper.MapperParsingException: failed to parse
-  // Cause: java.lang.IllegalArgumentException: surface form cannot contain unit separator character U+001F; this character is reserved
-  // which seems to come from data on this profile page https://twitter.com/kashiramojiao
-  // ヲタでネトウヨで女装子でアラフォーのキモいおっさんなのん
-  // (((o(´▽`)o)))
-  // I,m Ｊａｐａｎｅｓｅ　Otaku and Middle-aged man　and Patriot　and 　Conservatism.
-  // My Tweets combines the honesty and odiousness
-  test("strip value containing reserved control character x1F") {
-    val fv = FieldValue(datasets(0), 1L, 2L, 62L, "(((o(\u001F´▽`\u001F)o)))")
-    client.indexFieldValue(fv, refresh = true)
-    client.client
-      .prepareGet(config.es.index, config.es.fieldValueMapping.mappingType, fv.docId)
-      .execute.actionGet
-      .result[FieldValue].get.value should be("(((o(´▽`)o)))")
-  }
 }

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/client/SpandexElasticSearchClientSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/client/SpandexElasticSearchClientSpec.scala
@@ -4,7 +4,7 @@ import com.socrata.datacoordinator.secondary.LifecycleStage
 import com.socrata.spandex.common.client.ResponseExtensions._
 import com.socrata.spandex.common.{SpandexConfig, TestESData}
 import org.elasticsearch.action.index.IndexRequestBuilder
-import org.elasticsearch.common.unit.Fuzziness
+import org.elasticsearch.index.engine.IndexFailedEngineException
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSuiteLike, Matchers}
 
 // scalastyle:off
@@ -305,5 +305,32 @@ class SpandexElasticSearchClientSpec extends FunSuiteLike with Matchers with Bef
     a[IllegalArgumentException] shouldBe thrownBy {
       client.datasetCopyLatest(datasets(0), Some(Number(42))).get.copyNumber
     }
+  }
+
+  // previously, a blank value rendered the following json and caused an exception in lucene
+  // this is allegedly fixed in elasticsearch 1.5.3
+  // we could have fixed it by filtering out empty strings explicitly
+  // completion pre-analysis handles empty string by happy accident
+  test("handle value string is empty or null") {
+    try {
+      // org.elasticsearch.index.engine.IndexFailedEngineException: [spandex][2] Index failed for [field_value#primus.1234|2|3|60]
+      // Cause: java.lang.IllegalStateException: from state (0) already had transitions added
+      client.client.prepareIndex(config.es.index, config.es.fieldValueMapping.mappingType, "primus.1234|2|3|60")
+        .setSource(
+          """{
+            | "composite_id":"primus.1234|2|3",
+            | "copy_number":2,
+            | "dataset_id":"primus.1234",
+            | "row_id":60,
+            | "value":"",
+            | "column_id":3
+            |}""".
+            stripMargin)
+        .setRefresh(true).execute.actionGet
+    } catch {
+      case e: IndexFailedEngineException => // expected on previous versions
+    }
+
+    client.indexFieldValue(FieldValue(datasets(0), 1L, 2L, 61L, ""), refresh = true)
   }
 }

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/client/SpandexElasticSearchClientSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/client/SpandexElasticSearchClientSpec.scala
@@ -333,4 +333,21 @@ class SpandexElasticSearchClientSpec extends FunSuiteLike with Matchers with Bef
 
     client.indexFieldValue(FieldValue(datasets(0), 1L, 2L, 61L, ""), refresh = true)
   }
+
+  // once upon a time we got this exception:
+  // org.elasticsearch.index.mapper.MapperParsingException: failed to parse
+  // Cause: java.lang.IllegalArgumentException: surface form cannot contain unit separator character U+001F; this character is reserved
+  // which seems to come from data on this profile page https://twitter.com/kashiramojiao
+  // ヲタでネトウヨで女装子でアラフォーのキモいおっさんなのん
+  // (((o(´▽`)o)))
+  // I,m Ｊａｐａｎｅｓｅ　Otaku and Middle-aged man　and Patriot　and 　Conservatism.
+  // My Tweets combines the honesty and odiousness
+  test("strip value containing reserved control character x1F") {
+    val fv = FieldValue(datasets(0), 1L, 2L, 62L, "(((o(\u001F´▽`\u001F)o)))")
+    client.indexFieldValue(fv, refresh = true)
+    client.client
+      .prepareGet(config.es.index, config.es.fieldValueMapping.mappingType, fv.docId)
+      .execute.actionGet
+      .result[FieldValue].get.value should be("(((o(´▽`)o)))")
+  }
 }

--- a/spandex-secondary/src/main/scala/com.socrata.spandex.secondary/RowOpsHandler.scala
+++ b/spandex-secondary/src/main/scala/com.socrata.spandex.secondary/RowOpsHandler.scala
@@ -64,6 +64,8 @@ object RowOpsHandler {
                           copyNumber: Long,
                           rowId: RowId,
                           datum: (ColumnId, SoQLText)): FieldValue = datum match {
-    case (id, value) => FieldValue(datasetName, copyNumber, id.underlying, rowId.underlying, value.value)
+    case (id, value) => FieldValue(datasetName, copyNumber, id.underlying, rowId.underlying,
+      // *sigh* a cluster side analysis char_filter doesn't catch this one character in time.
+      value.value.replaceAll("\u001f", ""))
   }
 }


### PR DESCRIPTION
What's new
--------
+ Empty string should be fixed in https://github.com/elastic/elasticsearch/pull/11158 version 1.5.3 onward.
+ Control character unit separator (\x1F) is forbidden.

Performance benchmarks
--------
I am wary of adding a string replacement (regex) to the FieldValue constructor. Here is a performance estimate of the changes. No significant impact observed.

Before
```
Benchmark                                                                Mode  Cnt    Score    Error  Units
c.s.s.common.CompletionAnalyzerBenchmark.analyzeCompletionTokens         avgt   16  117.379 ±  2.723  us/op
c.s.s.secondary.ESIndexBenchmark.indexKeyword                            avgt   16  180.698 ± 21.023  ms/op
c.s.s.secondary.ESIndexBenchmark.indexPhrase                             avgt   16  202.310 ± 23.924  ms/op
```
After - string replacement in `new FieldValue()` constructor
```
Benchmark                                                                Mode  Cnt    Score    Error  Units
c.s.s.common.CompletionAnalyzerBenchmark.analyzeCompletionTokens         avgt   16  116.805 ±  5.649  us/op
c.s.s.secondary.ESIndexBenchmark.indexKeyword                            avgt   16  178.085 ± 28.357  ms/op
c.s.s.secondary.ESIndexBenchmark.indexPhrase                             avgt   16  194.008 ± 21.316  ms/op
```
After - string replacement in `RowOpsHandler.fieldValueFromDatum()` function
```
Benchmark                                                                Mode  Cnt    Score    Error  Units
c.s.s.common.CompletionAnalyzerBenchmark.analyzeCompletionTokens         avgt   16  115.659 ±  2.374  us/op
c.s.s.secondary.ESIndexBenchmark.indexKeyword                            avgt   16  175.888 ± 19.800  ms/op
c.s.s.secondary.ESIndexBenchmark.indexPhrase                             avgt   16  183.786 ±  9.351  ms/op
```