### PR TITLE
match tuning round 3

### DIFF
--- a/spandex-common/src/main/resources/reference.conf
+++ b/spandex-common/src/main/resources/reference.conf
@@ -42,7 +42,7 @@ com.socrata.spandex {
              "tokenizer":{
                "word":{
                  "type":"pattern",
-                 "pattern":"[\\p{C}\\p{P}\\p{Sm}\\p{Sk}\\p{So}\\p{Z}]+",
+                 "pattern":"[\\p{C}\\p{P}\\p{Sm}\\p{Sk}\\p{So}\\p{Z}&&[^\\&]]+",
                  "flags":"CASE_INSENSITIVE",
                  "group":-1
                }

--- a/spandex-common/src/main/resources/reference.conf
+++ b/spandex-common/src/main/resources/reference.conf
@@ -42,7 +42,7 @@ com.socrata.spandex {
              "tokenizer":{
                "word":{
                  "type":"pattern",
-                 "pattern":"[\\p{C}\\p{P}\\p{S}\\p{Z}]+",
+                 "pattern":"[\\p{C}\\p{P}\\p{Sm}\\p{Sk}\\p{So}\\p{Z}]+",
                  "flags":"CASE_INSENSITIVE",
                  "group":-1
                }

--- a/spandex-common/src/main/resources/reference.conf
+++ b/spandex-common/src/main/resources/reference.conf
@@ -42,7 +42,7 @@ com.socrata.spandex {
              "tokenizer":{
                "word":{
                  "type":"pattern",
-                 "pattern":"\\W+",
+                 "pattern":"[\\p{C}\\p{P}\\p{S}\\p{Z}]+",
                  "flags":"CASE_INSENSITIVE",
                  "group":-1
                }

--- a/spandex-common/src/main/scala/com/socrata/spandex/common/CompletionAnalyzer.scala
+++ b/spandex-common/src/main/scala/com/socrata/spandex/common/CompletionAnalyzer.scala
@@ -45,7 +45,8 @@ object CompletionAnalyzer {
 
 class CompletionAnalyzer(val config: AnalysisConfig) {
   val version = Try { Version.parseLeniently(config.luceneVersion) }.getOrElse(Version.LATEST)
-  val analyzer = new PatternAnalyzer(version, Pattern.compile( """[\p{C}\p{P}\p{Sm}\p{Sk}\p{So}\p{Z}]+"""))
+  val analyzer = new PatternAnalyzer(version, Pattern.compile(
+    """[\p{C}\p{P}\p{Sm}\p{Sk}\p{So}\p{Z}&&[^\&]]+"""))
 
   def analyze(value: String): List[String] = {
     @annotation.tailrec

--- a/spandex-common/src/main/scala/com/socrata/spandex/common/CompletionAnalyzer.scala
+++ b/spandex-common/src/main/scala/com/socrata/spandex/common/CompletionAnalyzer.scala
@@ -45,7 +45,7 @@ object CompletionAnalyzer {
 
 class CompletionAnalyzer(val config: AnalysisConfig) {
   val version = Try { Version.parseLeniently(config.luceneVersion) }.getOrElse(Version.LATEST)
-  val analyzer = new PatternAnalyzer(version, Pattern.compile( """\W+"""))
+  val analyzer = new PatternAnalyzer(version, Pattern.compile( """[\p{C}\p{P}\p{S}\p{Z}]+"""))
 
   def analyze(value: String): List[String] = {
     @annotation.tailrec

--- a/spandex-common/src/main/scala/com/socrata/spandex/common/CompletionAnalyzer.scala
+++ b/spandex-common/src/main/scala/com/socrata/spandex/common/CompletionAnalyzer.scala
@@ -45,7 +45,7 @@ object CompletionAnalyzer {
 
 class CompletionAnalyzer(val config: AnalysisConfig) {
   val version = Try { Version.parseLeniently(config.luceneVersion) }.getOrElse(Version.LATEST)
-  val analyzer = new PatternAnalyzer(version, Pattern.compile( """[\p{C}\p{P}\p{S}\p{Z}]+"""))
+  val analyzer = new PatternAnalyzer(version, Pattern.compile( """[\p{C}\p{P}\p{Sm}\p{Sk}\p{So}\p{Z}]+"""))
 
   def analyze(value: String): List[String] = {
     @annotation.tailrec

--- a/spandex-common/src/main/scala/com/socrata/spandex/common/CompletionAnalyzer.scala
+++ b/spandex-common/src/main/scala/com/socrata/spandex/common/CompletionAnalyzer.scala
@@ -45,6 +45,16 @@ object CompletionAnalyzer {
 
 class CompletionAnalyzer(val config: AnalysisConfig) {
   val version = Try { Version.parseLeniently(config.luceneVersion) }.getOrElse(Version.LATEST)
+  // In Lucene Pattern Tokenizer: delimiters separate tokens, and then are removed from indexing and analysis.
+  //
+  // The code points in this pattern are delimiters and all others are tokenizable.
+  // Delimiters include p{C} control characters, p{P} punctuation, p{S*} symbols (except currency),
+  // and p{Z} separators, but specifically exclude ampersand.
+  // That leaves tokenizable characters as p{L} letters from any language, p{M} combining marks,
+  // p{Sc} currency symbols, p{N} numbers, and by exclusion ampersand.
+  //
+  // This is better than the W nonword character class which defines tokenizable as a-zA-Z_0-9
+  // and all others, including non latin character set, as delimiters.
   val analyzer = new PatternAnalyzer(version, Pattern.compile(
     """[\p{C}\p{P}\p{Sm}\p{Sk}\p{So}\p{Z}&&[^\&]]+"""))
 

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/AnalyzerTest.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/AnalyzerTest.scala
@@ -38,6 +38,7 @@ trait AnalyzerTest {
 
   protected def analyzerAfterAll(): Unit = {
     client.deleteIndex()
+    client.close()
   }
 
   protected val ds = "ds.one"

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/CompletionAnalyzerSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/CompletionAnalyzerSpec.scala
@@ -147,4 +147,14 @@ class CompletionAnalyzerSpec extends FunSuiteLike with Matchers with AnalyzerTes
     // the config value 32 limits to -^ plus spaces, and a little more to preserve terms
     CompletionAnalyzer.analyze(value) should equal(expectedInputValues)
   }
+
+  test("match: non-english unicode") {
+    val expectedValue = "愛"
+
+    val tokens = CompletionAnalyzer.analyze(expectedValue)
+    tokens should contain(expectedValue)
+
+    index(expectedValue)
+    suggest(expectedValue) should contain(expectedValue)
+  }
 }

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/CompletionAnalyzerSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/CompletionAnalyzerSpec.scala
@@ -157,4 +157,15 @@ class CompletionAnalyzerSpec extends FunSuiteLike with Matchers with AnalyzerTes
     index(expectedValue)
     suggest(expectedValue) should contain(expectedValue)
   }
+
+  test("match: money") {
+    val expectedValue = "$500 and under"
+    val search = "$"
+
+    val tokens = CompletionAnalyzer.analyze(expectedValue)
+    tokens should contain(expectedValue)
+
+    index(expectedValue)
+    suggest(search) should contain(expectedValue)
+  }
 }

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/CompletionAnalyzerSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/CompletionAnalyzerSpec.scala
@@ -199,4 +199,10 @@ class CompletionAnalyzerSpec extends FunSuiteLike with Matchers with AnalyzerTes
     index(value)
     suggest(search) should contain(value)
   }
+
+  test("not match: dot") {
+    val value = "The quick and the dead"
+    index(value)
+    suggest(".") should be('empty)
+  }
 }

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/CompletionAnalyzerSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/CompletionAnalyzerSpec.scala
@@ -94,6 +94,10 @@ class CompletionAnalyzerSpec extends FunSuiteLike with Matchers with AnalyzerTes
 
   test("match: email") {
     val expectedValue = "we.are+awesome@socrata.com"
+
+    val tokens = CompletionAnalyzer.analyze(expectedValue)
+    tokens should contain("we are awesome socrata com")
+
     index(expectedValue)
     suggest("we") should contain(expectedValue)
     suggest("are") should contain(expectedValue)
@@ -104,12 +108,16 @@ class CompletionAnalyzerSpec extends FunSuiteLike with Matchers with AnalyzerTes
   }
 
   test("match: url") {
-    val expectedValue = "https://lucene.rocks/completion-suggester.html"
+    val expectedValue = "https://lucene.rocks/auto-suggester.html"
+
+    val tokens = CompletionAnalyzer.analyze(expectedValue)
+    tokens should contain("https lucene rocks auto suggester html")
+
     index(expectedValue)
     suggest("https") should contain(expectedValue)
     suggest("lucene") should contain(expectedValue)
     suggest("rocks") should contain(expectedValue)
-    suggest("completion") should contain(expectedValue)
+    suggest("auto") should contain(expectedValue)
     suggest("suggester") should contain(expectedValue)
     suggest("html") should contain(expectedValue)
     suggest("lucene rocks") should contain(expectedValue)
@@ -161,6 +169,17 @@ class CompletionAnalyzerSpec extends FunSuiteLike with Matchers with AnalyzerTes
   test("match: money") {
     val expectedValue = "$500 and under"
     val search = "$"
+
+    val tokens = CompletionAnalyzer.analyze(expectedValue)
+    tokens should contain(expectedValue)
+
+    index(expectedValue)
+    suggest(search) should contain(expectedValue)
+  }
+
+  test("match: ampersand") {
+    val expectedValue = "at&t mobility"
+    val search = "at&t"
 
     val tokens = CompletionAnalyzer.analyze(expectedValue)
     tokens should contain(expectedValue)

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/CompletionAnalyzerSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/CompletionAnalyzerSpec.scala
@@ -187,4 +187,16 @@ class CompletionAnalyzerSpec extends FunSuiteLike with Matchers with AnalyzerTes
     index(expectedValue)
     suggest(search) should contain(expectedValue)
   }
+
+  test("match: forward slash") {
+    val value = "andrea h/arthur d harris"
+    val expectedValue = "andrea h arthur d harris"
+    val search = "h/arthur"
+
+    val tokens = CompletionAnalyzer.analyze(value)
+    tokens should contain(expectedValue)
+
+    index(value)
+    suggest(search) should contain(value)
+  }
 }

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/KeywordAnalyzerSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/KeywordAnalyzerSpec.scala
@@ -121,4 +121,15 @@ class KeywordAnalyzerSpec extends FunSuiteLike with Matchers with AnalyzerTest w
     index(expectedValue)
     suggest(search) should contain(expectedValue)
   }
+
+  test("match: ampersand") {
+    val expectedValue = "AT&T Mobility"
+    val search = "AT&T"
+
+    val tokens = CompletionAnalyzer.analyze(expectedValue)
+    tokens should contain(expectedValue)
+
+    index(expectedValue)
+    suggest(search) should contain(expectedValue)
+  }
 }

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/KeywordAnalyzerSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/KeywordAnalyzerSpec.scala
@@ -143,4 +143,10 @@ class KeywordAnalyzerSpec extends FunSuiteLike with Matchers with AnalyzerTest w
     index(expectedValue)
     suggest(search) should contain(expectedValue)
   }
+
+  test("not match: dot") {
+    val value = "The quick and the dead"
+    index(value)
+    suggest(".") should be('empty)
+  }
 }

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/KeywordAnalyzerSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/KeywordAnalyzerSpec.scala
@@ -132,4 +132,15 @@ class KeywordAnalyzerSpec extends FunSuiteLike with Matchers with AnalyzerTest w
     index(expectedValue)
     suggest(search) should contain(expectedValue)
   }
+
+  test("match: forward slash") {
+    val expectedValue = "ANDREA H/ARTHUR D HARRIS"
+    val search = "ANDREA H/ARTHUR"
+
+    val tokens = CompletionAnalyzer.analyze(expectedValue)
+    tokens should contain(expectedValue)
+
+    index(expectedValue)
+    suggest(search) should contain(expectedValue)
+  }
 }

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/KeywordAnalyzerSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/KeywordAnalyzerSpec.scala
@@ -100,4 +100,14 @@ class KeywordAnalyzerSpec extends FunSuiteLike with Matchers with AnalyzerTest w
     val tokens = CompletionAnalyzer.analyze(value)
     tokens should equal(expectedTokens)
   }
+
+  test("match: non-english unicode") {
+    val expectedValue = "愛"
+
+    val tokens = CompletionAnalyzer.analyze(expectedValue)
+    tokens should contain(expectedValue)
+
+    index(expectedValue)
+    suggest(expectedValue) should contain(expectedValue)
+  }
 }

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/KeywordAnalyzerSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/KeywordAnalyzerSpec.scala
@@ -110,4 +110,15 @@ class KeywordAnalyzerSpec extends FunSuiteLike with Matchers with AnalyzerTest w
     index(expectedValue)
     suggest(expectedValue) should contain(expectedValue)
   }
+
+  test("match: money") {
+    val expectedValue = "$500 and under"
+    val search = "$"
+
+    val tokens = CompletionAnalyzer.analyze(expectedValue)
+    tokens should contain(expectedValue)
+
+    index(expectedValue)
+    suggest(search) should contain(expectedValue)
+  }
 }


### PR DESCRIPTION
What's new
--------
+ support Unicode character code points
+ treat as token string: currency symbols, ampersand
+ treat as delimiter: forward slash, dot

The delimiter and token Regex classes
--------
delimiters are one or more of these:

code point | description
-------- | --------
\p{C} | control characters
\p{P} | punctuation
\p{Sm} | symbols: math
\p{Sk} | symbols: modifier
\p{So} | symbols: other
\p{Z} | separators
&&[^\&] | exclude ampersand

What's left will be included in tokens:

code point | description
-------- | --------
\p{L} | letters from any language
\p{M} | marks to be combined with another character
\p{Sc} | symbols: currency
\p{N} | numbers
by exclusion | ampersand 