### PR TITLE
get buildinfo from sbtplugins

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,17 +5,15 @@ import org.scalatra.sbt._
 import pl.project13.scala.sbt.JmhPlugin
 import sbt.Keys._
 import sbt._
-import sbtbuildinfo.BuildInfoKeys._
-import sbtbuildinfo.{BuildInfoKey, BuildInfoOption, BuildInfoPlugin}
+import sbtbuildinfo.BuildInfoKeys.buildInfoPackage
+import sbtbuildinfo.BuildInfoPlugin
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
 object SpandexBuild extends Build {
   val Name = "com.socrata.spandex"
-  val ScalaVersion = "2.10.5"
   val JettyListenPort = 8042 // required for container embedded jetty
 
   lazy val commonSettings = Seq(
-    scalaVersion := ScalaVersion,
     resolvers ++= Deps.resolverList
   )
 
@@ -47,17 +45,9 @@ object SpandexBuild extends Build {
     "spandex-http",
     file("./spandex-http/"),
     settings = commonSettings ++ ScalatraPlugin.scalatraWithJRebel ++ scalateSettings ++ Seq(
-      buildInfoKeys := Seq[BuildInfoKey](
-        name,
-        version,
-        scalaVersion,
-        sbtVersion,
-        BuildInfoKey.action("buildTime") { System.currentTimeMillis },
-        BuildInfoKey.action("revision") { gitSha }),
       buildInfoPackage := "com.socrata.spandex.http",
-      buildInfoOptions += BuildInfoOption.ToMap,
       libraryDependencies ++= Deps.socrata ++ Deps.http ++ Deps.test ++ Deps.common,
-      coverageExcludedPackages := "<empty>;templates.*",
+      coverageExcludedPackages := "<empty>;templates.*;" + coverageExcludedPackages.value,
       scalateTemplateConfig in Compile <<= (sourceDirectory in Compile){ base =>
         Seq(
           TemplateConfig(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,5 @@ resolvers ++= Seq(
 addSbtPlugin("com.mojolly.scalate" % "xsbt-scalate-generator" % "0.5.0")
 addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "1.1.0")
 addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % "0.4.0")
-addSbtPlugin("com.socrata" %% "socrata-sbt-plugins" % "1.4.4")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.4.0")
+addSbtPlugin("com.socrata" %% "socrata-sbt-plugins" % "1.5.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.15")

--- a/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexServlet.scala
+++ b/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexServlet.scala
@@ -26,7 +26,9 @@ class SpandexServlet(conf: SpandexConfig,
   healthCheck("esClusterHealth") {Try {esClusterHealth}}
 
   get("/version") {
+    logger.info(">>> /version")
     contentType = ContentTypeJson
+    logger.info(s"<<< $version")
     version
   }
 

--- a/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexServlet.scala
+++ b/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexServlet.scala
@@ -26,9 +26,7 @@ class SpandexServlet(conf: SpandexConfig,
   healthCheck("esClusterHealth") {Try {esClusterHealth}}
 
   get("/version") {
-    logger.info(">>> /version")
     contentType = ContentTypeJson
-    logger.info(s"<<< $version")
     version
   }
 

--- a/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexServlet.scala
+++ b/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexServlet.scala
@@ -2,7 +2,6 @@ package com.socrata.spandex.http
 
 import javax.servlet.http.{HttpServletResponse => HttpStatus}
 
-import com.rojoma.json.v3.ast.{JObject, JString}
 import com.rojoma.json.v3.util.JsonUtil
 import com.socrata.spandex.common._
 import com.socrata.spandex.common.client._
@@ -15,7 +14,7 @@ class SpandexServlet(conf: SpandexConfig,
                      client: => SpandexElasticSearchClient) extends SpandexStack {
   def index: String = conf.es.index
 
-  val version = JsonUtil.renderJson(JObject(BuildInfo.toMap.mapValues(v => JString(v.toString))))
+  val version = BuildInfo.toJson
 
   def columnMap(datasetId: String, copyNum: Long, userColumnId: String): ColumnMap =
     client.columnMap(datasetId, copyNum, userColumnId).getOrElse(halt(

--- a/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexServlet.scala
+++ b/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexServlet.scala
@@ -93,6 +93,8 @@ class SpandexServlet(conf: SpandexConfig,
   }
 
   def suggest(f: (ColumnMap, String, Fuzziness, Int) => SpandexResult): String = {
+    logger.info(s">>> $requestPath params: $params")
+
     val paramFuzz = "fuzz"
     val paramSize = "size"
 
@@ -101,9 +103,10 @@ class SpandexServlet(conf: SpandexConfig,
     val stageInfoText = params.get(paramStageInfo).get
     val userColumnId = params.get(paramUserColumnId).get
     val text = urlDecode(params.get(paramText).getOrElse(""))
+    logger.info(s"urlDecoded param text -> $text")
+
     val fuzz = Fuzziness.build(params.getOrElse(paramFuzz, conf.suggestFuzziness))
     val size = params.get(paramSize).headOption.fold(conf.suggestSize)(_.toInt)
-    logger.info(s">>> $datasetId, $stageInfoText, $userColumnId, $text, ${fuzz.asDistance}, $size")
 
     val copy = copyNum(datasetId, stageInfoText)
     logger.info(s"found copy $copy")


### PR DESCRIPTION
get buildinfo from sbtplugins
will now look like this:
```
{
"name":"spandex-http", 
"buildTime":"2015-06-02T22:36:56.815Z", 
"scalaVersion":"2.10.5", 
"revision":"v1.0.0-1-g79969937d8020bca635db2acdcf7ce9cd2e82c80-dirty", 
"version":"1.0.1-SNAPSHOT", 
"sbtVersion":"0.13.8"
}
```

formerly looked like this:
```
{
"name":"spandex-http",
"buildTime":"1433201119946",
"scalaVersion":"2.10.4",
"revision":"v0.8.0-RC1-14-gcc1d52c656",
"version":"0.8.1-SNAPSHOT",
"sbtVersion":"0.13.8"
}
```

also stop logging /version calls, it's noisy 