### PR TITLE
Krah/jmx

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -127,7 +127,7 @@ object Deps {
     "org.elasticsearch" % "elasticsearch" % "1.4.4"
   )
   lazy val secondary = Seq(
-    "com.socrata" %% "secondarylib" % "0.7.1" exclude("org.slf4j", "slf4j-log4j12")
+    "com.socrata" %% "secondarylib" % "0.7.14" exclude("org.slf4j", "slf4j-log4j12")
       excludeAll ExclusionRule(organization = "com.rojoma")
   )
 }

--- a/spandex-http/docker/Dockerfile
+++ b/spandex-http/docker/Dockerfile
@@ -13,9 +13,11 @@ ENV SERVER_ARTIFACT  ${SERVER_NAME}-assembly.jar
 
 # Environment settings.
 ENV JAVA_XMX 512m
+ENV JMX_PORT 8049
 
 # Add other required resources to the container
 EXPOSE 8042
+EXPOSE 8049
 
 ADD ship.d /etc/ship.d
 ADD ${SERVER_CONFIG}.j2 /etc/

--- a/spandex-http/docker/ship.d/run
+++ b/spandex-http/docker/ship.d/run
@@ -10,4 +10,10 @@ exec su socrata -c "exec /usr/bin/java \
      -Xmx${JAVA_XMX} \
      -Xms${JAVA_XMX} \
      -Dconfig.file=/etc/${SERVER_CONFIG} \
+     -Djava.net.preferIPv4Stack=true \
+     -Dcom.sun.management.jmxremote.port=${JMX_PORT} \
+     -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT} \
+     -Dcom.sun.management.jmxremote.ssl=false \
+     -Dcom.sun.management.jmxremote.authenticate=false \
+     -Djava.rmi.server.hostname=${ARK_HOST:-localhost} \
      -jar $SERVER_JAR"

--- a/spandex-secondary/docker/Dockerfile
+++ b/spandex-secondary/docker/Dockerfile
@@ -1,7 +1,4 @@
-FROM registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/secondary-watcher:0.7.1-394
-
-# TODO expose JMX
-# EXPOSE 
+FROM registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/secondary-watcher:0.7.14-1889_1f65ac7f
 
 ENV SECONDARY_ARTIFACT spandex-secondary-assembly.jar
 ENV SECONDARY_CONFIG secondary.conf


### PR DESCRIPTION
* upgrade to data-coord 0.7.14 from Jul 28
  * previous version 0.7.1 from Apr 29, (comparison: https://github.com/socrata-platform/data-coordinator/compare/681c93cabb04095c4a18310dfcb6e99a0bb034e6...1f65ac7f70d70ea353970ed577dfa5611db44075)
  * increase http timeouts
  * static analysis
  * password rotation
  * run migrations when starting docker container
  * updated secondary job selection
  * set initially_claimed_at
  * automatic retry broken dataset
  * docker settings to expose jmx for secondary-watcher
  * add missing timezone
* expose jmx in spandex-http

verified working in my local stack