### PR TITLE
suggestions from disk index

### DIFF
--- a/spandex-common/src/main/resources/reference.conf
+++ b/spandex-common/src/main/resources/reference.conf
@@ -107,12 +107,16 @@ com.socrata.spandex {
                 "type": "string",
                 "index_analyzer": "case_insensitive_word_prefix",
                 "search_analyzer": "case_insensitive_word",
-                "copy_to": "value_keyword"
+                "copy_to": [ "value_keyword", "value_raw" ]
               },
               "value_keyword" : {
                 "type": "string",
                 "index_analyzer": "case_insensitive_keyword_prefix",
                 "search_analyzer": "case_insensitive_keyword"
+              },
+              "value_raw" : {
+                "type": "string",
+                "index": "not_analyzed"
               }
             }
         }"""

--- a/spandex-common/src/main/resources/reference.conf
+++ b/spandex-common/src/main/resources/reference.conf
@@ -30,6 +30,10 @@ com.socrata.spandex {
                  "tokenizer":"keyword",
                  "filter":["lowercase"]
                },
+               "case_insensitive_keyword_prefix":{
+                 "tokenizer":"keyword",
+                 "filter":["lowercase","prefix"]
+               },
                "case_insensitive_whitespace":{
                  "tokenizer":"whitespace",
                  "filter":["lowercase"]
@@ -38,14 +42,14 @@ com.socrata.spandex {
                  "tokenizer":"word",
                  "filter":["lowercase"]
                },
-               "case_insensitive_word_ngram":{
+               "case_insensitive_word_prefix":{
                  "tokenizer":"word",
-                 "filter":["lowercase","ngram"]
+                 "filter":["lowercase","prefix"]
                }
              },
              "filter":{
-               "ngram":{
-                 "type":"ngram",
+               "prefix":{
+                 "type":"edgeNGram",
                  "min_gram":1,
                  "max_gram":32
                }
@@ -101,7 +105,7 @@ com.socrata.spandex {
               "row_id" : { "type" : "long" },
               "value" : {
                 "type": "string",
-                "index_analyzer": "case_insensitive_word_ngram",
+                "index_analyzer": "case_insensitive_word_prefix",
                 "search_analyzer": "case_insensitive_word"
               }
             }

--- a/spandex-common/src/main/resources/reference.conf
+++ b/spandex-common/src/main/resources/reference.conf
@@ -7,7 +7,7 @@ com.socrata.spandex {
   suggest-size = 10
 
   analysis {
-    enabled = true
+    enabled = false
     lucene-version = "4.10.3"
     max-input-length = 64
     max-shingle-length = 32
@@ -37,6 +37,17 @@ com.socrata.spandex {
                "case_insensitive_word":{
                  "tokenizer":"word",
                  "filter":["lowercase"]
+               },
+               "case_insensitive_word_ngram":{
+                 "tokenizer":"word",
+                 "filter":["lowercase","ngram"]
+               }
+             },
+             "filter":{
+               "ngram":{
+                 "type":"ngram",
+                 "min_gram":1,
+                 "max_gram":32
                }
              },
              "tokenizer":{
@@ -87,21 +98,11 @@ com.socrata.spandex {
               "dataset_id" : { "type" : "string", "index": "not_analyzed" },
               "copy_number" : { "type" : "long" },
               "column_id" : { "type" : "long" },
-              "composite_id" : { "type" : "string", "index": "not_analyzed" },
               "row_id" : { "type" : "long" },
               "value" : {
-                "type": "completion",
-                "analyzer": "case_insensitive_word",
-                "payloads": false,
-                "preserve_separators": false,
-                "preserve_position_increments": false,
-                "max_input_length": 50,
-                "context" : {
-                  "composite_id" : {
-                    "type" : "category",
-                    "path" : "composite_id"
-                  }
-                }
+                "type": "string",
+                "index_analyzer": "case_insensitive_word_ngram",
+                "search_analyzer": "case_insensitive_word"
               }
             }
         }"""

--- a/spandex-common/src/main/resources/reference.conf
+++ b/spandex-common/src/main/resources/reference.conf
@@ -106,7 +106,13 @@ com.socrata.spandex {
               "value" : {
                 "type": "string",
                 "index_analyzer": "case_insensitive_word_prefix",
-                "search_analyzer": "case_insensitive_word"
+                "search_analyzer": "case_insensitive_word",
+                "copy_to": "value_keyword"
+              },
+              "value_keyword" : {
+                "type": "string",
+                "index_analyzer": "case_insensitive_keyword_prefix",
+                "search_analyzer": "case_insensitive_keyword"
               }
             }
         }"""

--- a/spandex-common/src/main/scala/com/socrata/spandex/common/SpandexConfig.scala
+++ b/spandex-common/src/main/scala/com/socrata/spandex/common/SpandexConfig.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeUnit
 import com.typesafe.config.{Config, ConfigFactory}
 
 class SpandexConfig(config: Config = ConfigFactory.load().getConfig("com.socrata.spandex")) {
-  val spandexPort        = config.getInt("port") // scalastyle:ignore multiple.string.literals
+  val spandexPort        = config.getInt("port")
   val es                 = new ElasticSearchConfig(config.getConfig("elastic-search"))
   val analysis           = new AnalysisConfig(config.getConfig("analysis"))
 
@@ -24,7 +24,7 @@ class AnalysisConfig(config: Config) {
 
 class ElasticSearchConfig(config: Config) {
   val host               = config.getString("host")
-  val port               = config.getInt("port") // scalastyle:ignore multiple.string.literals
+  val port               = config.getInt("port")
   val clusterName        = config.getString("cluster-name")
   val index              = config.getString("index")
   val settings           = config.getString("settings")

--- a/spandex-common/src/main/scala/com/socrata/spandex/common/client/ResponseExtensions.scala
+++ b/spandex-common/src/main/scala/com/socrata/spandex/common/client/ResponseExtensions.scala
@@ -88,26 +88,9 @@ case class FieldValue(datasetId: String,
                       rowId: Long,
                       value: String) {
   lazy val docId = FieldValue.makeDocId(datasetId, copyNumber, columnId, rowId)
-  lazy val compositeId = FieldValue.makeCompositeId(datasetId, copyNumber, columnId)
-  lazy val completionValue = CompletionValue(value)
-
-  // Needed for codec builder
-  def this(datasetId: String,
-           copyNumber: Long,
-           columnId: Long,
-           compositeId: String,
-           rowId: Long,
-           value: CompletionValue) = this(datasetId, copyNumber, columnId, rowId, value.output)
 }
 object FieldValue {
-  implicit val jCodec = SimpleJsonCodecBuilder[FieldValue].build(
-    SpandexFields.DatasetId, _.datasetId,
-    SpandexFields.CopyNumber, _.copyNumber,
-    SpandexFields.ColumnId, _.columnId,
-    SpandexFields.CompositeId, _.compositeId,
-    SpandexFields.RowId, _.rowId,
-    SpandexFields.Value, _.completionValue
-  )
+  implicit val jCodec = AutomaticJsonCodecBuilder[FieldValue]
 
   def apply(datasetName: String, copyNumber: Long, columnId: ColumnId, rowId: RowId, data: SoQLText): FieldValue =
     this(datasetName, copyNumber, columnId.underlying, rowId.underlying, data.value)

--- a/spandex-common/src/main/scala/com/socrata/spandex/common/client/ResponseExtensions.scala
+++ b/spandex-common/src/main/scala/com/socrata/spandex/common/client/ResponseExtensions.scala
@@ -2,11 +2,10 @@ package com.socrata.spandex.common.client
 
 import com.rojoma.json.v3.ast.{JString, JValue}
 import com.rojoma.json.v3.codec.{DecodeError, JsonDecode, JsonEncode}
-import com.rojoma.json.v3.util.{AutomaticJsonCodecBuilder, JsonKeyStrategy, JsonUtil, SimpleJsonCodecBuilder, Strategy}
+import com.rojoma.json.v3.util.{AutomaticJsonCodecBuilder, JsonKeyStrategy, JsonUtil, Strategy}
 import com.socrata.datacoordinator.id.{ColumnId, RowId}
 import com.socrata.datacoordinator.secondary.{ColumnInfo, LifecycleStage}
 import com.socrata.soql.types.SoQLText
-import com.socrata.spandex.common.CompletionAnalyzer
 import org.elasticsearch.action.get.GetResponse
 import org.elasticsearch.action.search.SearchResponse
 import org.elasticsearch.search.SearchHit
@@ -46,7 +45,6 @@ case class ColumnMap(datasetId: String,
                      systemColumnId: Long,
                      userColumnId: String) {
   lazy val docId = ColumnMap.makeDocId(datasetId, copyNumber, userColumnId)
-  lazy val compositeId = ColumnMap.makeCompositeId(datasetId, copyNumber, systemColumnId)
 }
 object ColumnMap {
   implicit val jCodec = AutomaticJsonCodecBuilder[ColumnMap]
@@ -63,22 +61,6 @@ object ColumnMap {
                 copyNumber: Long,
                 userColumnId: String): String =
     s"$datasetId|$copyNumber|$userColumnId"
-
-  def makeCompositeId(datasetId: String, copyNumber: Long, systemColumnId: Long): String =
-    s"$datasetId|$copyNumber|$systemColumnId"
-}
-
-@JsonKeyStrategy(Strategy.Underscore)
-case class CompletionValue(output: String) {
-  lazy val inputTokens = CompletionAnalyzer.analyze(output)
-
-  def this(inputTokens: List[String], output: String) = this(output)
-}
-object CompletionValue {
-  implicit val jCodec = SimpleJsonCodecBuilder[CompletionValue].build(
-    SpandexFields.ValueInput, _.inputTokens,
-    SpandexFields.ValueOutput, _.output
-  )
 }
 
 @JsonKeyStrategy(Strategy.Underscore)
@@ -97,9 +79,6 @@ object FieldValue {
 
   def makeDocId(datasetId: String, copyNumber: Long, columnId: Long, rowId: Long): String =
     s"$datasetId|$copyNumber|$columnId|$rowId"
-
-  def makeCompositeId(datasetId: String, copyNumber: Long, columnId: Long): String =
-    s"$datasetId|$copyNumber|$columnId"
 }
 
 @JsonKeyStrategy(Strategy.Underscore)

--- a/spandex-common/src/main/scala/com/socrata/spandex/common/client/SpandexElasticSearchClient.scala
+++ b/spandex-common/src/main/scala/com/socrata/spandex/common/client/SpandexElasticSearchClient.scala
@@ -20,7 +20,6 @@ import org.elasticsearch.search.aggregations.AggregationBuilders._
 import org.elasticsearch.search.aggregations.bucket.terms.Terms
 import org.elasticsearch.search.sort.SortOrder
 
-// scalastyle:off number.of.methods
 case class ElasticSearchResponseFailed(msg: String) extends Exception(msg)
 
 // Setting refresh to true on ES write calls, because we always want to be
@@ -33,6 +32,7 @@ case class ElasticSearchResponseFailed(msg: String) extends Exception(msg)
 // - refresh=true only guarantees consistency on a single shard.
 // - We aren't actually sure what the perf implications of running like this at production scale are.
 // http://www.elastic.co/guide/en/elasticsearch/reference/1.x/docs-index_.html#index-refresh
+// scalastyle:ignore number.of.methods
 class SpandexElasticSearchClient(config: ElasticSearchConfig) extends ElasticSearchClient(config) with Logging {
   protected def byDatasetIdQuery(datasetId: String): QueryBuilder = termQuery(SpandexFields.DatasetId, datasetId)
   protected def byDatasetIdAndStageQuery(datasetId: String, stage: LifecycleStage): QueryBuilder =

--- a/spandex-common/src/main/scala/com/socrata/spandex/common/client/SpandexElasticSearchClient.scala
+++ b/spandex-common/src/main/scala/com/socrata/spandex/common/client/SpandexElasticSearchClient.scala
@@ -330,7 +330,7 @@ class SpandexElasticSearchClient(config: ElasticSearchConfig) extends ElasticSea
     response.results[FieldValue](aggName)
   }
 
-  private def logElasticsearchRequest(request: SearchRequestBuilder): Unit = {
+  private[this] def logElasticsearchRequest(request: SearchRequestBuilder): Unit = {
     logger.info(s"executing elasticsearch request ${request.toString.replaceAll("""[\n\s]+""", " ")}")
   }
 }

--- a/spandex-common/src/main/scala/com/socrata/spandex/common/client/SpandexElasticSearchClient.scala
+++ b/spandex-common/src/main/scala/com/socrata/spandex/common/client/SpandexElasticSearchClient.scala
@@ -19,8 +19,6 @@ import org.elasticsearch.index.query.{FilterBuilder, QueryBuilder}
 import org.elasticsearch.search.aggregations.AggregationBuilders._
 import org.elasticsearch.search.aggregations.bucket.terms.Terms
 import org.elasticsearch.search.sort.SortOrder
-import org.elasticsearch.search.suggest.Suggest
-import org.elasticsearch.search.suggest.completion.CompletionSuggestionFuzzyBuilder
 
 // scalastyle:off number.of.methods
 case class ElasticSearchResponseFailed(msg: String) extends Exception(msg)

--- a/spandex-common/src/main/scala/com/socrata/spandex/common/client/SpandexFields.scala
+++ b/spandex-common/src/main/scala/com/socrata/spandex/common/client/SpandexFields.scala
@@ -9,5 +9,6 @@ object SpandexFields {
   val RowId        = "row_id"
   val Value        = "value"
   val ValueKeyword = "value_keyword"
+  val ValueRaw     = "value_raw"
   val Stage        = "stage"
 }

--- a/spandex-common/src/main/scala/com/socrata/spandex/common/client/SpandexFields.scala
+++ b/spandex-common/src/main/scala/com/socrata/spandex/common/client/SpandexFields.scala
@@ -8,8 +8,6 @@ object SpandexFields {
   val UserColumnId = "user_column_id"
   val RowId        = "row_id"
   val Value        = "value"
-  val ValueInput   = "input"
-  val ValueOutput  = "output"
-  val RawValue     = "raw"
+  val ValueKeyword = "value_keyword"
   val Stage        = "stage"
 }

--- a/spandex-common/src/test/resources/analysisOff.conf
+++ b/spandex-common/src/test/resources/analysisOff.conf
@@ -18,7 +18,17 @@ com.socrata.spandex {
               "value" : {
                 "type": "string",
                 "index_analyzer": "case_insensitive_keyword_prefix",
+                "search_analyzer": "case_insensitive_keyword",
+                "copy_to": [ "value_keyword", "value_raw" ]
+              },
+              "value_keyword" : {
+                "type": "string",
+                "index_analyzer": "case_insensitive_keyword_prefix",
                 "search_analyzer": "case_insensitive_keyword"
+              },
+              "value_raw" : {
+                "type": "string",
+                "index": "not_analyzed"
               }
             }
         }"""

--- a/spandex-common/src/test/resources/analysisOff.conf
+++ b/spandex-common/src/test/resources/analysisOff.conf
@@ -16,18 +16,9 @@ com.socrata.spandex {
               "composite_id" : { "type" : "string", "index": "not_analyzed" },
               "row_id" : { "type" : "long" },
               "value" : {
-                "type": "completion",
-                "analyzer": "case_insensitive_keyword",
-                "payloads": false,
-                "preserve_separators": false,
-                "preserve_position_increments": false,
-                "max_input_length": 50,
-                "context" : {
-                  "composite_id" : {
-                    "type" : "category",
-                    "path" : "composite_id"
-                  }
-                }
+                "type": "string",
+                "index_analyzer": "case_insensitive_keyword_prefix",
+                "search_analyzer": "case_insensitive_keyword"
               }
             }
         }"""

--- a/spandex-common/src/test/resources/analysisOn.conf
+++ b/spandex-common/src/test/resources/analysisOn.conf
@@ -21,7 +21,17 @@ com.socrata.spandex {
               "value" : {
                 "type": "string",
                 "index_analyzer": "case_insensitive_word_prefix",
-                "search_analyzer": "case_insensitive_word"
+                "search_analyzer": "case_insensitive_word",
+                "copy_to": [ "value_keyword", "value_raw" ]
+              },
+              "value_keyword" : {
+                "type": "string",
+                "index_analyzer": "case_insensitive_keyword_prefix",
+                "search_analyzer": "case_insensitive_keyword"
+              },
+              "value_raw" : {
+                "type": "string",
+                "index": "not_analyzed"
               }
             }
         }"""

--- a/spandex-common/src/test/resources/analysisOn.conf
+++ b/spandex-common/src/test/resources/analysisOn.conf
@@ -19,18 +19,9 @@ com.socrata.spandex {
               "composite_id" : { "type" : "string", "index": "not_analyzed" },
               "row_id" : { "type" : "long" },
               "value" : {
-                "type": "completion",
-                "analyzer": "case_insensitive_word",
-                "payloads": false,
-                "preserve_separators": false,
-                "preserve_position_increments": false,
-                "max_input_length": 50,
-                "context" : {
-                  "composite_id" : {
-                    "type" : "category",
-                    "path" : "composite_id"
-                  }
-                }
+                "type": "string",
+                "index_analyzer": "case_insensitive_word_prefix",
+                "search_analyzer": "case_insensitive_word"
               }
             }
         }"""

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/AnalyzerTest.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/AnalyzerTest.scala
@@ -50,15 +50,14 @@ trait AnalyzerTest {
   protected def index(value: String): Unit =
     index(FieldValue(col.datasetId, col.copyNumber, col.systemColumnId, docId, value))
   protected def index(fv: FieldValue): Unit = {
+    println(s"indexing $fv")
     client.indexFieldValue(fv, refresh = true)
     docId += 1
   }
 
-  protected def suggest(query: String, fuzz: Fuzziness = Fuzziness.ZERO): mutable.Buffer[String] = {
+  protected def suggest(query: String, fuzz: Fuzziness = Fuzziness.ZERO): Seq[String] = {
     val response = client.suggest(col, 10, query, fuzz, 2, 1)
-    val suggest = response.getSuggestion[Suggestion[Entry]]("suggest")
-    val entries = suggest.getEntries
-    val options = entries.get(0).getOptions
-    options.asScala.map(_.getText.toString)
+    println(s"response $response")
+    response.thisPage.map(_.value.toString)
   }
 }

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/AnalyzerTest.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/AnalyzerTest.scala
@@ -50,14 +50,12 @@ trait AnalyzerTest {
   protected def index(value: String): Unit =
     index(FieldValue(col.datasetId, col.copyNumber, col.systemColumnId, docId, value))
   protected def index(fv: FieldValue): Unit = {
-    println(s"indexing $fv")
     client.indexFieldValue(fv, refresh = true)
     docId += 1
   }
 
   protected def suggest(query: String, fuzz: Fuzziness = Fuzziness.ZERO): Seq[String] = {
     val response = client.suggest(col, 10, query, fuzz, 2, 1)
-    println(s"response $response")
     response.thisPage.map(_.value.toString)
   }
 }

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/CompletionAnalyzerSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/CompletionAnalyzerSpec.scala
@@ -148,7 +148,7 @@ class CompletionAnalyzerSpec extends FunSuiteLike with Matchers with AnalyzerTes
   }
 
   test("match: non-english unicode") {
-    val expectedValue = "愛" // scalastyle:ignore
+    val expectedValue = "愛"
 
     val tokens = CompletionAnalyzer.analyze(expectedValue)
     tokens should contain(expectedValue)

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/CompletionAnalyzerSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/CompletionAnalyzerSpec.scala
@@ -194,6 +194,7 @@ class CompletionAnalyzerSpec extends FunSuiteLike with Matchers with AnalyzerTes
     val search = "h/arthur"
 
     val tokens = CompletionAnalyzer.analyze(value)
+    println(tokens)
     tokens should contain(expectedValue)
 
     index(value)

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/CompletionAnalyzerSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/CompletionAnalyzerSpec.scala
@@ -73,15 +73,6 @@ class CompletionAnalyzerSpec extends FunSuiteLike with Matchers with AnalyzerTes
     tokens should equal(expectedTokens)
   }
 
-  test("field value json includes value input/output elements") {
-    val value = "Donuts and Coconuts"
-    val expectedInputTokens = List("donuts", "and", "coconuts")
-    val fv = FieldValue(col.datasetId, col.copyNumber, col.systemColumnId, 11, value)
-    val json = JsonUtil.renderJson(fv)
-    json should include("\"input\":[")
-    json should include("\"output\":")
-  }
-
   test("match: term") {
     val expectedValue = "Former President Abraham Lincoln"
     index(expectedValue)
@@ -194,7 +185,6 @@ class CompletionAnalyzerSpec extends FunSuiteLike with Matchers with AnalyzerTes
     val search = "h/arthur"
 
     val tokens = CompletionAnalyzer.analyze(value)
-    println(tokens)
     tokens should contain(expectedValue)
 
     index(value)

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/KeywordAnalyzerSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/KeywordAnalyzerSpec.scala
@@ -102,7 +102,7 @@ class KeywordAnalyzerSpec extends FunSuiteLike with Matchers with AnalyzerTest w
   }
 
   test("match: non-english unicode") {
-    val expectedValue = "愛" // scalastyle:ignore
+    val expectedValue = "愛"
 
     val tokens = CompletionAnalyzer.analyze(expectedValue)
     tokens should contain(expectedValue)

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/TestESData.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/TestESData.scala
@@ -9,9 +9,9 @@ trait TestESData {
   val datasets = Seq("primus.1234", "primus.9876")
 
   def copies(dataset: String): Seq[DatasetCopy] = {
-    val snapshot    = DatasetCopy(dataset, 1, 5, LifecycleStage.Snapshotted) // scalastyle:ignore magic.number
-    val published   = DatasetCopy(dataset, 2, 10, LifecycleStage.Published) // scalastyle:ignore magic.number
-    val workingCopy = DatasetCopy(dataset, 3, 15, LifecycleStage.Unpublished) // scalastyle:ignore magic.number
+    val snapshot    = DatasetCopy(dataset, 1, 5, LifecycleStage.Snapshotted)
+    val published   = DatasetCopy(dataset, 2, 10, LifecycleStage.Published)
+    val workingCopy = DatasetCopy(dataset, 3, 15, LifecycleStage.Unpublished)
     Seq(snapshot, published, workingCopy).sortBy(_.copyNumber)
   }
 

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/client/SpandexElasticSearchClientSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/client/SpandexElasticSearchClientSpec.scala
@@ -7,7 +7,6 @@ import org.elasticsearch.action.index.IndexRequestBuilder
 import org.elasticsearch.index.engine.IndexFailedEngineException
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSuiteLike, Matchers}
 
-// scalastyle:off
 class SpandexElasticSearchClientSpec extends FunSuiteLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach with TestESData {
   val config = new SpandexConfig
   val client = new TestESClient(config.es)

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/client/SpandexElasticSearchClientSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/client/SpandexElasticSearchClientSpec.scala
@@ -247,7 +247,7 @@ class SpandexElasticSearchClientSpec extends FunSuiteLike with Matchers with Bef
     client.datasetCopy(datasets(0), 2) should not be ('defined)
   }
 
-  ignore("samples") {
+  test("samples") {
     val column = ColumnMap(datasets(0), 1, 1, "col1-1111")
 
     val samples = client.sample(column, 10)
@@ -260,7 +260,7 @@ class SpandexElasticSearchClientSpec extends FunSuiteLike with Matchers with Bef
     samples.aggs should contain(BucketCount(makeRowData(1, 5), 1))
   }
 
-  ignore("lots of samples") {
+  test("lots of samples") {
     val ds = datasets(0)
     val cp = copies(ds)(1)
     val col = ColumnMap(ds, cp.copyNumber, 42L, "col42")
@@ -279,7 +279,7 @@ class SpandexElasticSearchClientSpec extends FunSuiteLike with Matchers with Bef
     retrieved.aggs.sortBy(_.key) should be(expected)
   }
 
-  ignore("sort by frequency") {
+  test("sort by frequency") {
     val ds = datasets(0)
     val cp = copies(ds)(1)
     val col = ColumnMap(ds, cp.copyNumber, 47L, "col47")

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/client/TestESClient.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/client/TestESClient.scala
@@ -44,7 +44,6 @@ class TestESClient(config: ElasticSearchConfig, local: Boolean = true) extends S
   def deleteAllDatasetCopies(): Unit =
     deleteByQuery(termQuery("_type", config.datasetCopyMapping), Seq(config.datasetCopyMapping.mappingType))
 
-
   def searchColumnMapsByDataset(datasetId: String): SearchResults[ColumnMap] =
     client.prepareSearch(config.index)
           .setTypes(config.columnMapMapping.mappingType)

--- a/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexResult.scala
+++ b/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexResult.scala
@@ -7,7 +7,6 @@ import org.elasticsearch.search.suggest.Suggest.Suggestion
 import org.elasticsearch.search.suggest.completion.CompletionSuggestion.Entry
 
 import scala.collection.JavaConverters._
-import scala.util.Try
 
 case class SpandexOption(text: String, score: Option[Float])
 
@@ -25,7 +24,7 @@ object SpandexResult {
     val entries = suggest.getEntries
     val options = entries.get(0).getOptions
     SpandexResult(options.asScala.map { a =>
-      SpandexOption(a.getText.string(), Try{Some(a.getScore)}.getOrElse(None))
+      SpandexOption(a.getText.string(), Option(a.getScore))
     })
   }
 

--- a/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexResult.scala
+++ b/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexResult.scala
@@ -29,14 +29,16 @@ object SpandexResult {
     })
   }
 
-  /* Not yet used.
-   * Transforms a search result with aggregation into spandex result options
-   */
-  def apply(response: SearchResults[FieldValue]): SpandexResult =
-    SpandexResult(response.thisPage.map { src =>
+  def apply(response: SearchResults[FieldValue]): SpandexResult = {
+    val hits = response.thisPage.map { src =>
       // TODO: aggregate with doc count
-      SpandexOption(src.value, Some(42))
-    })
+      SpandexOption(src.value, None)
+    }
+    val buckets = response.aggs.map { bc =>
+      SpandexOption(bc.key, Some(bc.docCount))
+    }
+    SpandexResult(hits ++ buckets)
+  }
 
   object Fields {
     private[this] def formatQuotedString(s: String) = "\"%s\"" format s

--- a/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexResult.scala
+++ b/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexResult.scala
@@ -33,8 +33,9 @@ object SpandexResult {
    * Transforms a search result with aggregation into spandex result options
    */
   def apply(response: SearchResults[FieldValue]): SpandexResult =
-    SpandexResult(response.aggs.map { src =>
-      SpandexOption(src.key, Some(src.docCount))
+    SpandexResult(response.thisPage.map { src =>
+      // TODO: aggregate with doc count
+      SpandexOption(src.value, Some(42))
     })
 
   object Fields {

--- a/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexServlet.scala
+++ b/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexServlet.scala
@@ -56,7 +56,7 @@ class SpandexServlet(conf: SpandexConfig,
     }.call()
   }
 
-  /* How to get all the results out of Lucene.
+  /* How to get all the results out of Lucene FST.
    * Ignore the provided text and fuzziness parameters and replace as follows.
    * Text "1 character" => blank string is not allowed, but through the fuzziness below
    *                       this 1 character will be factored out.
@@ -73,7 +73,7 @@ class SpandexServlet(conf: SpandexConfig,
     timer("suggestSample") {
       params.get(paramText) match {
         case None => suggest { (col, _, _, size) =>
-          SpandexResult(client.suggest(col, size, sampleText, sampleFuzz, sampleFuzzLen, sampleFuzzPre))
+          SpandexResult(client.sample(col, size))
         }
         case Some(s) => suggest { (col, text, fuzz, size) =>
           SpandexResult(client.suggest(col, size, text, fuzz, conf.suggestFuzzLength, conf.suggestFuzzPrefix))
@@ -104,7 +104,7 @@ class SpandexServlet(conf: SpandexConfig,
     logger.info(s"urlDecoded param text -> $text")
 
     val fuzz = Fuzziness.build(params.getOrElse(paramFuzz, conf.suggestFuzziness))
-    val size = params.get(paramSize).headOption.fold(conf.suggestSize)(_.toInt)
+    val size = params.get(paramSize).fold(conf.suggestSize)(_.toInt)
 
     val copy = copyNum(datasetId, stageInfoText)
     logger.info(s"found copy $copy")

--- a/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexServlet.scala
+++ b/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexServlet.scala
@@ -56,19 +56,6 @@ class SpandexServlet(conf: SpandexConfig,
     }.call()
   }
 
-  /* How to get all the results out of Lucene FST.
-   * Ignore the provided text and fuzziness parameters and replace as follows.
-   * Text "1 character" => blank string is not allowed, but through the fuzziness below
-   *                       this 1 character will be factored out.
-   * Fuzziness ONE => approximately allows 1 edit distance from the given to result texts.
-   * Fuzz Length 0 => start giving fuzzy results from any length of input text.
-   * Fuzz Prefix 0 => allow all results no matter how badly matched.
-   * TA-DA!
-   */
-  private[this] val sampleText = "a"
-  private[this] val sampleFuzz = Fuzziness.ONE
-  private[this] val sampleFuzzLen = 0
-  private[this] val sampleFuzzPre = 0
   get(s"/$routeSuggest/:$paramDatasetId/:$paramStageInfo/:$paramUserColumnId") {
     timer("suggestSample") {
       params.get(paramText) match {
@@ -115,15 +102,6 @@ class SpandexServlet(conf: SpandexConfig,
     val result = f(column, text, fuzz, size)
     logger.info(s"<<< $result")
     JsonUtil.renderJson(result)
-  }
-
-  /* Not yet used.
-   * sample endpoint exposes query by column with aggregation on doc count
-   */
-  get(s"/sample/:$paramDatasetId/:$paramStageInfo/:$paramUserColumnId") {
-    timer("sample") {
-      suggest { (col, _, _, size) => SpandexResult(client.sample(col, size)) }
-    }.call()
   }
 
 }

--- a/spandex-http/src/test/scala/com/socrata/spandex/http/SpandexResultSpec.scala
+++ b/spandex-http/src/test/scala/com/socrata/spandex/http/SpandexResultSpec.scala
@@ -47,7 +47,7 @@ class SpandexResultSpec extends FunSuiteLike with ShouldMatchers with TestESData
     js should include(opt3String)
   }
 
-  test("json enocde empty result") {
+  test("json encode empty result") {
     val js = JsonUtil.renderJson(SpandexResult(Seq.empty))
     js should include(optionsEmptyJson)
   }

--- a/spandex-http/src/test/scala/com/socrata/spandex/http/SpandexResultSpec.scala
+++ b/spandex-http/src/test/scala/com/socrata/spandex/http/SpandexResultSpec.scala
@@ -62,7 +62,7 @@ class SpandexResultSpec extends FunSuiteLike with ShouldMatchers with TestESData
     js should include(rows(col)(0).value)
   }
 
-  ignore("transform from search response") {
+  test("transform from search response") {
     val ds = datasets(0)
     val copy = copies(ds)(1)
     val col = columns(ds, copy)(2)

--- a/spandex-http/src/test/scala/com/socrata/spandex/http/SpandexResultSpec.scala
+++ b/spandex-http/src/test/scala/com/socrata/spandex/http/SpandexResultSpec.scala
@@ -7,7 +7,6 @@ import com.socrata.spandex.http.SpandexResult.Fields._
 import org.elasticsearch.common.unit.Fuzziness
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, ShouldMatchers}
 
-// scalastyle:off magic.number
 class SpandexResultSpec extends FunSuiteLike with ShouldMatchers with TestESData with BeforeAndAfterAll {
   val config = new SpandexConfig
   val client = new TestESClient(config.es)

--- a/spandex-http/src/test/scala/com/socrata/spandex/http/SpandexServletSpec.scala
+++ b/spandex-http/src/test/scala/com/socrata/spandex/http/SpandexServletSpec.scala
@@ -109,9 +109,9 @@ class SpandexServletSpec extends ScalatraSuite with FunSuiteLike with TestESData
     }
     get(s"$routeSuggest/$dsid/$copynum/$colid/$text", (paramSize, "1")) {
       status should equal(HttpStatus.SC_OK)
-      body should include(makeRowData(colsysid, 1))
+      body shouldNot include(makeRowData(colsysid, 1))
       body shouldNot include(makeRowData(colsysid, 2))
-      body shouldNot include(makeRowData(colsysid, 3))
+      body should include(makeRowData(colsysid, 3))
       body shouldNot include(makeRowData(colsysid, 4))
       body shouldNot include(makeRowData(colsysid, 5))
     }

--- a/spandex-http/src/test/scala/com/socrata/spandex/http/SpandexServletSpec.scala
+++ b/spandex-http/src/test/scala/com/socrata/spandex/http/SpandexServletSpec.scala
@@ -66,6 +66,7 @@ class SpandexServletSpec extends ScalatraSuite with FunSuiteLike with TestESData
   private[this] val colsysid = col.systemColumnId
   private[this] val colid = col.userColumnId
   private[this] val textPrefix = "dat"
+
   test("suggest - some hits") {
     get(s"$routeSuggest/$dsid/$copynum/$colid/$textPrefix") {
       status should equal(HttpStatus.SC_OK)
@@ -109,9 +110,9 @@ class SpandexServletSpec extends ScalatraSuite with FunSuiteLike with TestESData
     }
     get(s"$routeSuggest/$dsid/$copynum/$colid/$text", (paramSize, "1")) {
       status should equal(HttpStatus.SC_OK)
-      body shouldNot include(makeRowData(colsysid, 1))
+      body should include(makeRowData(colsysid, 1))
       body shouldNot include(makeRowData(colsysid, 2))
-      body should include(makeRowData(colsysid, 3))
+      body shouldNot include(makeRowData(colsysid, 3))
       body shouldNot include(makeRowData(colsysid, 4))
       body shouldNot include(makeRowData(colsysid, 5))
     }

--- a/spandex-http/src/test/scala/com/socrata/spandex/http/SpandexServletSpec.scala
+++ b/spandex-http/src/test/scala/com/socrata/spandex/http/SpandexServletSpec.scala
@@ -170,27 +170,6 @@ class SpandexServletSpec extends ScalatraSuite with FunSuiteLike with TestESData
     }
   }
 
-  ignore("sample") {
-    get(s"$routeSample/$dsid/$copynum/$colid") {
-      contentTypeShouldBe(ContentTypeJson)
-      status should equal(HttpStatus.SC_OK)
-      body should include(optionsJson)
-      body should include(makeRowData(colsysid, 2))
-    }
-  }
-
-  ignore("sample without required params should return 404") {
-    get(s"$routeSample/$dsid/$copynum") {
-      status should equal(HttpStatus.SC_NOT_FOUND)
-    }
-    get(s"$routeSample/$dsid") {
-      status should equal(HttpStatus.SC_NOT_FOUND)
-    }
-    get(s"$routeSample") {
-      status should equal(HttpStatus.SC_NOT_FOUND)
-    }
-  }
-
   test("suggest - copy stage invalid should return 400") {
     val donut = "donut"
     get(s"$routeSuggest/$dsid/$donut/$colid/$textPrefix") {

--- a/spandex-http/src/test/scala/com/socrata/spandex/http/SpandexSpec.scala
+++ b/spandex-http/src/test/scala/com/socrata/spandex/http/SpandexSpec.scala
@@ -14,7 +14,7 @@ class SpandexSpec extends FunSuiteLike with MustMatchers {
     }
     thread.start()
     while (!Spandex.ready) {
-      Thread.sleep(1000) // scalastyle:ignore magic.number
+      Thread.sleep(1000)
     }
     thread.interrupt()
   }

--- a/spandex-perf/src/main/scala/com/socrata/spandex/common/CompletionAnalyzerBenchmark.scala
+++ b/spandex-perf/src/main/scala/com/socrata/spandex/common/CompletionAnalyzerBenchmark.scala
@@ -4,7 +4,6 @@ import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
 
-// scalastyle:off magic.number
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/spandex-perf/src/main/scala/com/socrata/spandex/common/ESSuggestBenchmark.scala
+++ b/spandex-perf/src/main/scala/com/socrata/spandex/common/ESSuggestBenchmark.scala
@@ -39,6 +39,7 @@ class ESSuggestBenchmark extends MarvelNames {
   val version = 3L
   val stage = LifecycleStage.Published
   val col = ColumnMap(datasetId, copyNumber, systemColumnId, userColumndId)
+
   @Setup(Level.Iteration)
   def setupDataset(): Unit = {
     client.putDatasetCopy(datasetId, copyNumber, version, stage, refresh = false)

--- a/spandex-perf/src/main/scala/com/socrata/spandex/common/ESSuggestBenchmark.scala
+++ b/spandex-perf/src/main/scala/com/socrata/spandex/common/ESSuggestBenchmark.scala
@@ -1,0 +1,92 @@
+package com.socrata.spandex.common
+
+import java.util.concurrent.TimeUnit
+
+import com.socrata.datacoordinator.secondary.LifecycleStage
+import com.socrata.spandex.common.client.{ColumnMap, FieldValue}
+import org.elasticsearch.action.index.IndexRequestBuilder
+import org.elasticsearch.common.unit.Fuzziness
+import org.openjdk.jmh.annotations._
+
+import scala.util.Random
+
+// scalastyle:off magic.number
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 8)
+@Measurement(iterations = 4)
+@Threads(1)
+@Fork(value = 4)
+class ESSuggestBenchmark extends MarvelNames {
+  val client = new PerfESClient
+  val maxInput = 32
+
+  @Setup(Level.Trial)
+  def setupIndex(): Unit = {
+    client.bootstrapData()
+  }
+
+  @TearDown(Level.Trial)
+  def teardownIndex(): Unit = {
+    client.removeBootstrapData()
+  }
+
+  val datasetId = "optimus.42"
+  var copyNumber = 1L
+  val systemColumnId = 2L
+  val userColumndId = "dead-beef"
+  val version = 3L
+  val stage = LifecycleStage.Published
+  val col = ColumnMap(datasetId, copyNumber, systemColumnId, userColumndId)
+  @Setup(Level.Iteration)
+  def setupDataset(): Unit = {
+    client.putDatasetCopy(datasetId, copyNumber, version, stage, refresh = false)
+    client.putColumnMap(ColumnMap(datasetId, copyNumber, systemColumnId, userColumndId), refresh = false)
+    copyNumber += 1
+    index()
+    gcUltra()
+  }
+
+  @TearDown(Level.Iteration)
+  def teardownDataset(): Unit = {
+    client.deleteFieldValuesByDataset(datasetId)
+    client.deleteColumnMapsByDataset(datasetId)
+    client.deleteDatasetCopiesByDataset(datasetId)
+    client.refresh()
+    Thread.sleep(1000L) // make sure the index is clear before next iteration
+  }
+
+  def index(): Unit = {
+    @annotation.tailrec
+    def go(n: Int, acc: List[IndexRequestBuilder]): List[IndexRequestBuilder] = n match {
+      case 0 => acc
+      case n: Int =>
+        val fv = FieldValue(datasetId, copyNumber, systemColumnId, n, anotherPhrase)
+        go(n - 1, client.fieldValueIndexRequest(fv) :: acc)
+    }
+    client.sendBulkRequest(go(10000, Nil), refresh = true)
+  }
+
+  private[this] def gcUltra(): Unit = {
+    for {i <- 0 to 3} {
+      Runtime.getRuntime.gc()
+      Thread.sleep(55)
+    }
+  }
+
+  @Benchmark
+  def suggest(): Unit = {
+    @annotation.tailrec
+    def go(n: Int): Unit = {
+      if (n > 0) {
+        val r = Random.nextInt(maxInput)
+        val s = anotherPhrase
+        val sub = s.substring(0, Math.min(r, s.length))
+        client.suggest(col, 10, sub, Fuzziness.ZERO, 0, 0)
+        go(n - 1)
+      }
+    }
+    go(10000)
+  }
+}

--- a/spandex-perf/src/main/scala/com/socrata/spandex/secondary/ESIndexBenchmark.scala
+++ b/spandex-perf/src/main/scala/com/socrata/spandex/secondary/ESIndexBenchmark.scala
@@ -34,6 +34,7 @@ class ESIndexBenchmark extends MarvelNames {
   val columnUserId = "dead-beef"
   val version = 3L
   val stage = LifecycleStage.Published
+
   @Setup(Level.Iteration)
   def setupDataset(): Unit = {
     client.putDatasetCopy(datasetId, copyNum, version, stage, refresh = false)

--- a/spandex-perf/src/main/scala/com/socrata/spandex/secondary/ESIndexBenchmark.scala
+++ b/spandex-perf/src/main/scala/com/socrata/spandex/secondary/ESIndexBenchmark.scala
@@ -8,7 +8,6 @@ import com.socrata.spandex.common.{MarvelNames, PerfESClient}
 import org.elasticsearch.action.index.IndexRequestBuilder
 import org.openjdk.jmh.annotations._
 
-// scalastyle:off magic.number
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)

--- a/spandex-secondary/src/main/scala/com.socrata.spandex.secondary/SecondaryEventLogger.scala
+++ b/spandex-secondary/src/main/scala/com.socrata.spandex.secondary/SecondaryEventLogger.scala
@@ -3,7 +3,6 @@ package com.socrata.spandex.secondary
 import com.typesafe.scalalogging.slf4j.Logging
 import com.socrata.datacoordinator.secondary.ColumnInfo
 
-// scalastyle:off multiple.string.literals
 trait SecondaryEventLogger extends Logging {
   private[this] def logEvent(eventName: String, description: String): Unit =
     logger.info(s"$eventName event: $description")

--- a/spandex-secondary/src/main/scala/com.socrata.spandex.secondary/SpandexSecondary.scala
+++ b/spandex-secondary/src/main/scala/com.socrata.spandex.secondary/SpandexSecondary.scala
@@ -39,13 +39,13 @@ trait SpandexSecondaryLike extends Secondary[SoQLType, SoQLValue] with Logging {
   def wantsWorkingCopies: Boolean = true
 
   def currentVersion(datasetInternalName: String, cookie: Cookie): Long =
-    throw new NotImplementedError("Not used anywhere yet") // scalastyle:ignore multiple.string.literals
+    throw new NotImplementedError("Not used anywhere yet")
 
   def currentCopyNumber(datasetInternalName: String, cookie: Cookie): Long =
-    throw new NotImplementedError("Not used anywhere yet") // scalastyle:ignore multiple.string.literals
+    throw new NotImplementedError("Not used anywhere yet")
 
   def snapshots(datasetInternalName: String, cookie: Cookie): Set[Long] =
-    throw new NotImplementedError("Not used anywhere yet") // scalastyle:ignore multiple.string.literals
+    throw new NotImplementedError("Not used anywhere yet")
 
   def dropDataset(datasetInternalName: String, cookie: Cookie): Unit = {
     client.deleteFieldValuesByDataset(datasetInternalName)

--- a/spandex-secondary/src/test/scala/com/socrata/spandex/secondary/DatasetLifecycleSimulation.scala
+++ b/spandex-secondary/src/test/scala/com/socrata/spandex/secondary/DatasetLifecycleSimulation.scala
@@ -18,7 +18,6 @@ import org.scalatest.{Matchers, FunSuiteLike}
  * and capturing the batches of events that were passed to spandex secondary.
  * This test aims to be a good starting point to understand how the spandex secondary works.
  */
-// scalastyle:off
 class DatasetLifecycleSimulation extends FunSuiteLike with Matchers {
   val config = new SpandexConfig(ConfigFactory.load().getConfig("com.socrata.spandex")
     .withValue("elastic-search.index", ConfigValueFactory.fromAnyRef("spandex-dataset-lifecycle")))

--- a/spandex-secondary/src/test/scala/com/socrata/spandex/secondary/SpandexSecondaryLikeSpec.scala
+++ b/spandex-secondary/src/test/scala/com/socrata/spandex/secondary/SpandexSecondaryLikeSpec.scala
@@ -20,12 +20,11 @@ class TestSpandexSecondary(config: ElasticSearchConfig) extends SpandexSecondary
   def shutdown(): Unit = client.close()
 }
 
-// scalastyle:off
 class SpandexSecondaryLikeSpec extends FunSuiteLike with Matchers with TestESData with BeforeAndAfterEach with BeforeAndAfterAll {
   lazy val config = new SpandexConfig
   lazy val secondary = new TestSpandexSecondary(config.es)
 
-  def client = secondary.client
+  def client: TestESClient = secondary.client
 
   override protected def beforeAll(): Unit = SpandexBootstrap.ensureIndex(config.es, client)
 

--- a/spandex-secondary/src/test/scala/com/socrata/spandex/secondary/VersionEventsHandlerSpec.scala
+++ b/spandex-secondary/src/test/scala/com/socrata/spandex/secondary/VersionEventsHandlerSpec.scala
@@ -14,7 +14,6 @@ import org.joda.time.DateTime
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSuiteLike, Matchers}
 
-// scalastyle:off
 class VersionEventsHandlerSpec extends FunSuiteLike
                                   with Matchers
                                   with BeforeAndAfterAll
@@ -40,14 +39,14 @@ class VersionEventsHandlerSpec extends FunSuiteLike
     val invalidDataVersion = 0
     val events = Seq(Truncated).iterator
 
-    an [IllegalArgumentException] should be thrownBy handler.handle("alpha.75", invalidDataVersion, events)
+    an[IllegalArgumentException] should be thrownBy handler.handle("alpha.75", invalidDataVersion, events)
   }
 
   test("WorkingCopyCreated - throw an exception if multiple working copies are encountered in the same event sequence") {
     val copyInfo = CopyInfo(new CopyId(100), 1, LifecycleStage.Unpublished, 1, DateTime.now)
     val events = Seq(WorkingCopyCreated(copyInfo), WorkingCopyCreated(copyInfo)).iterator
 
-    a [UnsupportedOperationException] should be thrownBy handler.handle("alpha.75", 1, events)
+    a[UnsupportedOperationException] should be thrownBy handler.handle("alpha.75", 1, events)
   }
 
   test("WorkingCopyCreated - throw an exception if the copy to be created already exists") {
@@ -58,7 +57,7 @@ class VersionEventsHandlerSpec extends FunSuiteLike
 
     client.putDatasetCopy(dataset, copyInfo.copyNumber, dataVersion, copyInfo.lifecycleStage, refresh = true)
 
-    a [ResyncSecondaryException] should be thrownBy handler.handle(dataset, 1, events)
+    a[ResyncSecondaryException] should be thrownBy handler.handle(dataset, 1, events)
   }
 
   test("WorkingCopyCreated - a new dataset copy should be added to the index") {
@@ -141,7 +140,7 @@ class VersionEventsHandlerSpec extends FunSuiteLike
   test("WorkingCopyPublished - throw exception if the current copy is not Unpublished.") {
     client.putDatasetCopy("wcp-invalid-test", 1, 2, LifecycleStage.Published, refresh = true)
 
-    an [InvalidStateBeforeEvent] should be thrownBy
+    an[InvalidStateBeforeEvent] should be thrownBy
       handler.handle("wcp-invalid-test", 3, Seq(WorkingCopyPublished).iterator)
   }
 
@@ -172,7 +171,7 @@ class VersionEventsHandlerSpec extends FunSuiteLike
     val expectedBefore = Some(DatasetCopy("wcd-test-initial-copy", 1, 1, LifecycleStage.Unpublished))
     client.datasetCopyLatest("wcd-test-initial-copy") should be(expectedBefore)
 
-    an [InvalidStateBeforeEvent] should be thrownBy
+    an[InvalidStateBeforeEvent] should be thrownBy
       handler.handle("wcd-test-initial-copy", 2, Seq(WorkingCopyDropped).iterator)
   }
 
@@ -182,7 +181,7 @@ class VersionEventsHandlerSpec extends FunSuiteLike
     val expectedBefore = Some(DatasetCopy("wcd-test-published", 2, 2, LifecycleStage.Published))
     client.datasetCopyLatest("wcd-test-published") should be(expectedBefore)
 
-    an [InvalidStateBeforeEvent] should be thrownBy
+    an[InvalidStateBeforeEvent] should be thrownBy
       handler.handle("wcd-test-published", 3, Seq(WorkingCopyDropped).iterator)
   }
 
@@ -216,7 +215,7 @@ class VersionEventsHandlerSpec extends FunSuiteLike
 
     val copyInfo = CopyInfo(new CopyId(100), 2, LifecycleStage.Unpublished, 2, DateTime.now)
     val events =  Seq(SnapshotDropped(copyInfo)).iterator
-    an [InvalidStateBeforeEvent] should be thrownBy handler.handle("sd-test-notsnapshot", 3, events)
+    an[InvalidStateBeforeEvent] should be thrownBy handler.handle("sd-test-notsnapshot", 3, events)
   }
 
   test("SnapshotDropped - the specified snapshot should be dropped") {


### PR DESCRIPTION
addresses #68
suggestion time increased to 175% of previous, which is acceptable.
index time memory allocations dropped to 59% of previous, and with the index being stored on disk it should fade out of active memory naturally over time.

benchmark summaries:
all expenses paid
```
[info] Benchmark                          Mode  Cnt     Score     Error  Units
[info] ESSuggestBenchmark.suggest         avgt   16  2087.518 ± 161.728  ms/op
```
without doc count query
```
[info] Benchmark                                                                Mode  Cnt    Score    Error  Units
[info] c.s.s.common.CompletionAnalyzerBenchmark.analyzeCompletionTokens         avgt   16  115.608 ±  4.350  us/op
[info] c.s.s.secondary.ESIndexBenchmark.indexKeyword                            avgt   16  110.553 ± 20.704  ms/op
[info] c.s.s.secondary.ESIndexBenchmark.indexPhrase                             avgt   16  148.281 ±  3.929  ms/op

[info] ESIndexBenchmark.indexKeyword                                   avgt   16         99.034 ±       22.399   ms/op
[info] ESIndexBenchmark.indexKeyword:·gc.alloc.rate                    avgt   16        529.941 ±       91.756  MB/sec
[info] ESIndexBenchmark.indexKeyword:·gc.alloc.rate.norm               avgt   16  130277025.664 ±  1604773.826    B/op
[info] ESIndexBenchmark.indexKeyword:·gc.churn.PS_Eden_Space           avgt   16        512.563 ±      318.465  MB/sec
[info] ESIndexBenchmark.indexKeyword:·gc.churn.PS_Eden_Space.norm      avgt   16  116641849.200 ± 66445648.071    B/op
[info] ESIndexBenchmark.indexKeyword:·gc.churn.PS_Old_Gen              avgt   16          0.145 ±        0.263  MB/sec
[info] ESIndexBenchmark.indexKeyword:·gc.churn.PS_Old_Gen.norm         avgt   16      40004.777 ±    79728.025    B/op
[info] ESIndexBenchmark.indexKeyword:·gc.churn.PS_Perm_Gen             avgt   16         ≈ 10⁻⁴                 MB/sec
[info] ESIndexBenchmark.indexKeyword:·gc.churn.PS_Perm_Gen.norm        avgt   16         18.744 ±       15.916    B/op
[info] ESIndexBenchmark.indexKeyword:·gc.churn.PS_Survivor_Space       avgt   16          4.439 ±        1.258  MB/sec
[info] ESIndexBenchmark.indexKeyword:·gc.churn.PS_Survivor_Space.norm  avgt   16    1145163.249 ±   439025.664    B/op
[info] ESIndexBenchmark.indexKeyword:·gc.count                         avgt   16        139.000                 counts
[info] ESIndexBenchmark.indexKeyword:·gc.time                          avgt   16       4076.000                     ms
[info] ESIndexBenchmark.indexPhrase                                    avgt   16        125.336 ±       11.185   ms/op
[info] ESIndexBenchmark.indexPhrase:·gc.alloc.rate                     avgt   16        759.892 ±       63.986  MB/sec
[info] ESIndexBenchmark.indexPhrase:·gc.alloc.rate.norm                avgt   16  242982345.605 ±  2087913.884    B/op
[info] ESIndexBenchmark.indexPhrase:·gc.churn.PS_Eden_Space            avgt   16        799.454 ±       28.358  MB/sec
[info] ESIndexBenchmark.indexPhrase:·gc.churn.PS_Eden_Space.norm       avgt   16  257390631.752 ± 25286960.868    B/op
[info] ESIndexBenchmark.indexPhrase:·gc.churn.PS_Old_Gen               avgt   16          0.088 ±        0.064  MB/sec
[info] ESIndexBenchmark.indexPhrase:·gc.churn.PS_Old_Gen.norm          avgt   16      28780.053 ±    21305.678    B/op
[info] ESIndexBenchmark.indexPhrase:·gc.churn.PS_Perm_Gen              avgt   16         ≈ 10⁻⁴                 MB/sec
[info] ESIndexBenchmark.indexPhrase:·gc.churn.PS_Perm_Gen.norm         avgt   16         27.655 ±       20.636    B/op
[info] ESIndexBenchmark.indexPhrase:·gc.churn.PS_Survivor_Space        avgt   16          7.131 ±        0.404  MB/sec
[info] ESIndexBenchmark.indexPhrase:·gc.churn.PS_Survivor_Space.norm   avgt   16    2297223.339 ±   263432.586    B/op
[info] ESIndexBenchmark.indexPhrase:·gc.count                          avgt   16        144.000                 counts
[info] ESIndexBenchmark.indexPhrase:·gc.time                           avgt   16       4072.000                     ms

[info] ESSuggestBenchmark.suggest         avgt   16  1538.747 ± 317.999  ms/op
```
previously
```
[info] Benchmark                                                                Mode  Cnt    Score    Error  Units
[info] c.s.s.common.CompletionAnalyzerBenchmark.analyzeCompletionTokens         avgt   16  114.496 ±  3.544  us/op
[info] c.s.s.secondary.ESIndexBenchmark.indexKeyword                            avgt   16  162.774 ±  6.349  ms/op
[info] c.s.s.secondary.ESIndexBenchmark.indexPhrase                             avgt   16  202.855 ± 25.170  ms/op

[info] ESIndexBenchmark.indexKeyword                                   avgt   16        140.958 ±       19.971   ms/op
[info] ESIndexBenchmark.indexKeyword:·gc.alloc.rate                    avgt   16        891.021 ±       99.848  MB/sec
[info] ESIndexBenchmark.indexKeyword:·gc.alloc.rate.norm               avgt   16  317288910.442 ±  1659707.762    B/op
[info] ESIndexBenchmark.indexKeyword:·gc.churn.PS_Eden_Space           avgt   16        946.922 ±       24.514  MB/sec
[info] ESIndexBenchmark.indexKeyword:·gc.churn.PS_Eden_Space.norm      avgt   16  342537299.513 ± 54377844.178    B/op
[info] ESIndexBenchmark.indexKeyword:·gc.churn.PS_Old_Gen              avgt   16          0.227 ±        0.645  MB/sec
[info] ESIndexBenchmark.indexKeyword:·gc.churn.PS_Old_Gen.norm         avgt   16      78701.188 ±   219535.521    B/op
[info] ESIndexBenchmark.indexKeyword:·gc.churn.PS_Perm_Gen             avgt   16         ≈ 10⁻⁴                 MB/sec
[info] ESIndexBenchmark.indexKeyword:·gc.churn.PS_Perm_Gen.norm        avgt   16         29.667 ±       17.032    B/op
[info] ESIndexBenchmark.indexKeyword:·gc.churn.PS_Survivor_Space       avgt   16          3.841 ±        0.391  MB/sec
[info] ESIndexBenchmark.indexKeyword:·gc.churn.PS_Survivor_Space.norm  avgt   16    1392249.296 ±   278919.764    B/op
[info] ESIndexBenchmark.indexKeyword:·gc.count                         avgt   16        144.000                 counts
[info] ESIndexBenchmark.indexKeyword:·gc.time                          avgt   16       4157.000                     ms
[info] ESIndexBenchmark.indexPhrase                                    avgt   16        164.295 ±       27.527   ms/op
[info] ESIndexBenchmark.indexPhrase:·gc.alloc.rate                     avgt   16        869.184 ±      106.271  MB/sec
[info] ESIndexBenchmark.indexPhrase:·gc.alloc.rate.norm                avgt   16  355961273.045 ±  1372824.493    B/op
[info] ESIndexBenchmark.indexPhrase:·gc.churn.PS_Eden_Space            avgt   16        888.992 ±      181.758  MB/sec
[info] ESIndexBenchmark.indexPhrase:·gc.churn.PS_Eden_Space.norm       avgt   16  369787087.360 ± 87935589.692    B/op
[info] ESIndexBenchmark.indexPhrase:·gc.churn.PS_Old_Gen               avgt   16          0.058 ±        0.018  MB/sec
[info] ESIndexBenchmark.indexPhrase:·gc.churn.PS_Old_Gen.norm          avgt   16      24875.937 ±    10498.224    B/op
[info] ESIndexBenchmark.indexPhrase:·gc.churn.PS_Perm_Gen              avgt   16         ≈ 10⁻⁴                 MB/sec
[info] ESIndexBenchmark.indexPhrase:·gc.churn.PS_Perm_Gen.norm         avgt   16         36.071 ±       30.033    B/op
[info] ESIndexBenchmark.indexPhrase:·gc.churn.PS_Survivor_Space        avgt   16          5.577 ±        0.413  MB/sec
[info] ESIndexBenchmark.indexPhrase:·gc.churn.PS_Survivor_Space.norm   avgt   16    2315335.304 ±   335743.104    B/op
[info] ESIndexBenchmark.indexPhrase:·gc.count                          avgt   16        145.000                 counts
[info] ESIndexBenchmark.indexPhrase:·gc.time                           avgt   16       4159.000                     ms

[info] ESSuggestBenchmark.suggest                 avgt   16  1191.591 ± 211.906  ms/op
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/socrata-platform/spandex/69)
<!-- Reviewable:end -->