### PR TITLE
EN-4323: Update to use new secondary-watcher

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -128,7 +128,7 @@ object Deps {
     "org.elasticsearch" % "elasticsearch" % "1.7.2"
   )
   lazy val secondary = Seq(
-    "com.socrata" %% "secondarylib" % "2.1.12" exclude("org.slf4j", "slf4j-log4j12")
+    "com.socrata" %% "secondarylib" % "2.1.16" exclude("org.slf4j", "slf4j-log4j12")
       excludeAll ExclusionRule(organization = "com.rojoma")
   )
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -128,7 +128,7 @@ object Deps {
     "org.elasticsearch" % "elasticsearch" % "1.7.2"
   )
   lazy val secondary = Seq(
-    "com.socrata" %% "secondarylib" % "2.1.16" exclude("org.slf4j", "slf4j-log4j12")
+    "com.socrata" %% "secondarylib" % "3.0.1" exclude("org.slf4j", "slf4j-log4j12")
       excludeAll ExclusionRule(organization = "com.rojoma")
   )
 }

--- a/spandex-secondary/docker/Dockerfile
+++ b/spandex-secondary/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/secondary-watcher:2.1.12_5681_db0be9bd
+FROM registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/secondary-watcher:2.1.16_6085_6c69662f
 
 ENV SECONDARY_ARTIFACT spandex-secondary-assembly.jar
 ENV SECONDARY_CONFIG secondary.conf

--- a/spandex-secondary/docker/Dockerfile
+++ b/spandex-secondary/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/secondary-watcher:2.1.16_6085_6c69662f
+FROM registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/secondary-watcher:3.0.1_6329_11316ad4
 
 ENV SECONDARY_ARTIFACT spandex-secondary-assembly.jar
 ENV SECONDARY_CONFIG secondary.conf

--- a/spandex-secondary/src/test/scala/com/socrata/spandex/secondary/SpandexSecondaryLikeSpec.scala
+++ b/spandex-secondary/src/test/scala/com/socrata/spandex/secondary/SpandexSecondaryLikeSpec.scala
@@ -60,7 +60,9 @@ class SpandexSecondaryLikeSpec extends FunSuiteLike with Matchers with TestESDat
     client.searchColumnMapsByCopyNumber(datasets(0), 1).totalHits should be (3)
     client.searchColumnMapsByCopyNumber(datasets(0), 2).totalHits should be (3)
 
-    secondary.dropCopy(datasets(0), 2, None)
+    val datasetInfo = DatasetInfo(datasets(0), "en-US", Array.empty)
+    val copyInfo = CopyInfo(new CopyId(100), 2, LifecycleStage.Published, 10, DateTime.now)
+    secondary.dropCopy(datasetInfo, copyInfo, None, isLatestCopy = true)
 
     client.searchFieldValuesByCopyNumber(datasets(0), 1).totalHits should be (15)
     client.searchFieldValuesByCopyNumber(datasets(0), 2).totalHits should be (0)
@@ -72,7 +74,9 @@ class SpandexSecondaryLikeSpec extends FunSuiteLike with Matchers with TestESDat
 
   test("drop future copy") {
     client.datasetCopy(datasets(0), 7) should not be 'defined
-    secondary.dropCopy(datasets(0), 7, None)
+    val datasetInfo = DatasetInfo(datasets(0), "en-US", Array.empty)
+    val copyInfo = CopyInfo(new CopyId(200), 7, LifecycleStage.Published, 77, DateTime.now)
+    secondary.dropCopy(datasetInfo, copyInfo, None, isLatestCopy = true)
   }
 
   test("resync") {
@@ -111,7 +115,7 @@ class SpandexSecondaryLikeSpec extends FunSuiteLike with Matchers with TestESDat
         new ColumnId(4) -> new SoQLNumber(new BigDecimal(3)))
     )
 
-    secondary.resync(datasetInfo, copyInfo, schema, None, unmanaged(rows.iterator), Seq.empty, isLatestCopy = true)
+    secondary.resync(datasetInfo, copyInfo, schema, None, unmanaged(rows.iterator), Seq.empty, isLatestLivingCopy = true)
 
     val copies = client.searchCopiesByDataset("zoo-animals")
     copies.totalHits should be (1)


### PR DESCRIPTION
Must also update version of secondaryLib
Secondary.dropCopy(.) parameter change