### PR TITLE
EN-6995: handle OutOfMemoryError gracefully

### DIFF
--- a/spandex-secondary/docker/ship.d/run-with-log-level
+++ b/spandex-secondary/docker/ship.d/run-with-log-level
@@ -23,6 +23,7 @@ exec su socrata -c '/usr/bin/java \
     -Dcom.sun.management.jmxremote.ssl=false \
     -Dcom.sun.management.jmxremote.authenticate=false \
     -Djava.rmi.server.hostname=${ARK_HOST:-localhost} \
+    -XX:+ExitOnOutOfMemoryError \
     -jar $SERVER_ARTIFACT \
     com.socrata.datacoordinator.secondary.SecondaryWatcher \
     '


### PR DESCRIPTION
With Java 8, we need to add this flag to handle OutOfMemoryError the way we want to. Otherwise the worker threads will crash but the main thread won't.