### PR TITLE
EN-4585: Improved secondary-watcher claims

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -130,7 +130,7 @@ object Deps {
     "org.elasticsearch" % "elasticsearch" % "1.7.2"
   )
   lazy val secondary = Seq(
-    "com.socrata" %% "secondarylib" % "3.0.14"
+    "com.socrata" %% "secondarylib" % "3.3.0"
   )
   lazy val secondaryFiltered =
     secondary.map(_.exclude("org.slf4j", "slf4j-log4j12")


### PR DESCRIPTION
Use new secondaryLib library version with:
 - retry logic for releasing claims
 - in memory "working set" of  claimed datasets
   to prevent from re-claiming a dataset
   whose claim we failed to release
 - health check on claim update happening
   on desired interval