### PR TITLE
EN-13225: Bump secondary-watcher version

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -130,7 +130,7 @@ object Deps {
     "org.elasticsearch" % "elasticsearch" % "1.7.2"
   )
   lazy val secondary = Seq(
-    "com.socrata" %% "secondarylib" % "3.3.0"
+    "com.socrata" %% "secondarylib" % "3.3.3"
   )
   lazy val secondaryFiltered =
     secondary.map(_.exclude("org.slf4j", "slf4j-log4j12")


### PR DESCRIPTION
Main changes:
 * secondary-watcher updates version on the secondary manifest
   in a new transaction.

Other changes:
 * restrict resync datasets of the same secondary group to happen
   one at a time. Since spandex and spandex-plus are a group
   where a dataset should only be (functionally) replicated to one
   or the other at a time this shouldn't change resync behavior
   for the secondary.

Refs EN-13224

This depends on migration in truth to create the resync table.
568cc622e645772311af84cf7204e7dbbebc7319 (data-coordinator)