### PR TITLE
EN-13224: Fix regression where resync never breaks

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -130,7 +130,7 @@ object Deps {
     "org.elasticsearch" % "elasticsearch" % "1.7.2"
   )
   lazy val secondary = Seq(
-    "com.socrata" %% "secondarylib" % "3.3.3"
+    "com.socrata" %% "secondarylib" % "3.3.4"
   )
   lazy val secondaryFiltered =
     secondary.map(_.exclude("org.slf4j", "slf4j-log4j12")


### PR DESCRIPTION
Fix regression where `secondary_manifest.retry_num`
is not incremented when there is an error in resync.

The fix is in the secondary-watcher library code.