### PR TITLE
EN-12729: Avoid deadlocks with new SW lib version

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -130,7 +130,7 @@ object Deps {
     "org.elasticsearch" % "elasticsearch" % "1.7.2"
   )
   lazy val secondary = Seq(
-    "com.socrata" %% "secondarylib" % "3.3.4"
+    "com.socrata" %% "secondarylib" % "3.3.5"
   )
   lazy val secondaryFiltered =
     secondary.map(_.exclude("org.slf4j", "slf4j-log4j12")


### PR DESCRIPTION
Avoid deadlocks when updating multiple rows on the
`secondary_manifest` by first obtaining locks on
the rows in a deterministic order, i.e. ordery by
`dataset_system_id` then`store_id`.